### PR TITLE
fix: makefile spaces and file case sensitivity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+configurations/openApi/*
+!configurations/openApi/empty
+docs

--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ local:
 	docker-compose logs -f "msm"
 	rm -rf ./docs/
 	mkdir -p ./docs/
-	mv ./configurations/openApi/* ./docs/
+	ls -1 ./configurations/openApi | grep -v empty | xargs -I{} mv ./configurations/openApi/{} ./docs/
 
 # Build and run the Docker container
 container:
@@ -21,6 +21,6 @@ container:
 # Shut down testing containers and clean house
 down:
 	docker compose --profile msmtest down
-    docker compose --profile testing down
-    docker image prune -f
-    docker volume prune -f
+	docker compose --profile testing down
+	docker image prune -f
+	docker volume prune -f


### PR DESCRIPTION
Just a few things I found while checking out the repo.

- Mix of spaces & tabs in the makefile
- Linux vs Mac folder name case sensitivity

I did also have a question in reviewing the Readme - I'm not sure how I can get a `./msm` executable like the Readme is showing here:

![image](https://github.com/agile-learning-institute/mongoSchemaManagerTemplate/assets/877908/4f117b84-850d-4496-9960-acc9bdbee01e)